### PR TITLE
fix(popupconnected): fix bug where element appears below ref element

### DIFF
--- a/projects/hal-components/package.json
+++ b/projects/hal-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hafslundnett/hal-components",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "scripts": {
     "build": "..\\..\\node_modules\\.bin\\tsc -p tsconfig.schematics.json",
     "copy:schemas": "cp --parents schematics/*/schema.json ..\\..\\dist\\hal-components\\",

--- a/projects/hal-components/src/lib/animations.ts
+++ b/projects/hal-components/src/lib/animations.ts
@@ -100,3 +100,22 @@ export const listAnimation: AnimationTriggerMetadata = trigger('listAnimation', 
     })
   ])
 ]);
+
+export const popUpAnimation: AnimationTriggerMetadata = trigger('popUpAnimation', [
+  state(
+    'void',
+    style({
+      opacity: 0,
+      transform: 'scale(0.7)'
+    })
+  ),
+  state(
+    '*',
+    style({
+      opacity: 1,
+      transform: 'scale(1)'
+    })
+  ),
+  transition('void => *', animate(`150ms`)),
+  transition('* => void', animate(`150ms`))
+]);

--- a/projects/hal-components/src/lib/components/popup-connected/popup-connected.component.html
+++ b/projects/hal-components/src/lib/components/popup-connected/popup-connected.component.html
@@ -8,7 +8,7 @@
   [cdkConnectedOverlayScrollStrategy]="scrollStrategy"
   (detach)="onClose()"
 >
-  <div class="animation-wrapper" @scaleUp role="dialog">
+  <div class="animation-wrapper" @popUpAnimation role="dialog">
     <div class="arrow-above" *ngIf="relativePositionY === 'below'"></div>
     <div 
       class="connected-popup-body" 

--- a/projects/hal-components/src/lib/components/popup-connected/popup-connected.component.ts
+++ b/projects/hal-components/src/lib/components/popup-connected/popup-connected.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, Output, OnInit, EventEmitter, OnChanges, SimpleChanges } from '@angular/core';
 import { CdkOverlayOrigin, ConnectionPositionPair, ScrollStrategy, Overlay } from '@angular/cdk/overlay';
-import { scaleUp } from '../../animations';
+import { popUpAnimation } from '../../animations';
 export type popupPosition = 'above' | 'below';
 
 // Is missing support for relativePositionX (horisontal). Add if needed
@@ -9,7 +9,7 @@ export type popupPosition = 'above' | 'below';
   selector: 'hal-popup-connected',
   templateUrl: './popup-connected.component.html',
   styleUrls: ['./popup-connected.component.scss'],
-  animations: [scaleUp]
+  animations: [popUpAnimation]
 })
 export class PopupConnectedComponent implements OnInit, OnChanges {
 


### PR DESCRIPTION
Popup no longer appears for a moment below the ref element, when having a popup above the ref
element.

+ Added new popupAnimation constant