### PR TITLE
improvement(closeable-row): Overflow visible when expanded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Update [4.1.0]
+# Update [4.0.0]
 
 ## Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
-# Update [4.0.0]
+# Update [4.1.0]
 
 ## Breaking changes
 
 ### App Shell:
 New shell design. This will most likely not break anything, but the small design changes may cause some minor problems. The new shell is slightly bigger by a few pixels
 
+## Minor changes
+
+### Closeable-row
+Overflow is now set to visible when panel is expanded, and hidden when panel is closed. 
 
 # Update [3.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,6 @@
 ### App Shell:
 New shell design. This will most likely not break anything, but the small design changes may cause some minor problems. The new shell is slightly bigger by a few pixels
 
-## Minor changes
-
-### Closeable-row
-Overflow is now set to visible when panel is expanded, and hidden when panel is closed. 
-
 # Update [3.0.0]
 
 ## Breaking changes

--- a/projects/hal-components/package.json
+++ b/projects/hal-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hafslundnett/hal-components",
-  "version": "4.1.0",
+  "version": "4.0.1",
   "scripts": {
     "build": "..\\..\\node_modules\\.bin\\tsc -p tsconfig.schematics.json",
     "copy:schemas": "cp --parents schematics/*/schema.json ..\\..\\dist\\hal-components\\",

--- a/projects/hal-components/package.json
+++ b/projects/hal-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hafslundnett/hal-components",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "scripts": {
     "build": "..\\..\\node_modules\\.bin\\tsc -p tsconfig.schematics.json",
     "copy:schemas": "cp --parents schematics/*/schema.json ..\\..\\dist\\hal-components\\",

--- a/projects/hal-components/src/lib/components/closeable-row/closeable-row.component.html
+++ b/projects/hal-components/src/lib/components/closeable-row/closeable-row.component.html
@@ -1,6 +1,11 @@
 <mat-accordion #topLevelElement class="closable-root">
-  <mat-expansion-panel [expanded]="startExpanded" (afterCollapse)="toggle()" (opened)="toggle()">
-    <mat-expansion-panel-header>
+  <mat-expansion-panel 
+    [expanded]="startExpanded" 
+    (afterCollapse)="toggle()" 
+    (afterExpand)="toggle()" 
+    [ngClass]="showOverflow ? 'overflow-visible' : ''"
+    >
+    <mat-expansion-panel-header (click)="headerClicked()">
       <mat-panel-title>
         <ng-content select="RowHeader"></ng-content>
       </mat-panel-title>

--- a/projects/hal-components/src/lib/components/closeable-row/closeable-row.component.scss
+++ b/projects/hal-components/src/lib/components/closeable-row/closeable-row.component.scss
@@ -28,4 +28,9 @@
   }
 }
 
+.overflow-visible {
+  overflow: visible !important;
+}
+
+
 

--- a/projects/hal-components/src/lib/components/closeable-row/closeable-row.component.spec.ts
+++ b/projects/hal-components/src/lib/components/closeable-row/closeable-row.component.spec.ts
@@ -131,6 +131,31 @@ describe('CloseableRowComponent', () => {
     });
   });
 
+  describe('should have overflow visible panel is expanded', () => {
+
+    beforeEach(() => {
+      component.startExpanded = true;
+      component.toggleEnabled = true;
+      fixture.detectChanges();
+    });
+
+    it('shoud have overflow visible when panel is expanded', () => {
+      expect(component.showOverflow).toBeTruthy();
+    });
+  });
+
+  describe('should have overflow hidden when panel is closed', () => {
+
+    beforeEach(() => {
+      component.startExpanded = false;
+      fixture.detectChanges();
+    });
+
+    it('shoud have overflow visible when panel is expanded', () => {
+      expect(component.showOverflow).toBeFalsy();
+    });
+  });
+
   function getElementStyle(selector: string) {
     return fixture.debugElement.nativeElement.querySelector(selector).style.cssText;
   }

--- a/projects/hal-components/src/lib/components/closeable-row/closeable-row.component.ts
+++ b/projects/hal-components/src/lib/components/closeable-row/closeable-row.component.ts
@@ -15,6 +15,8 @@ export class CloseableRowComponent implements OnInit, AfterViewInit {
 
   showContent = false;
   toggleEnabled = false;
+  showOverflow = false;
+  isChangingState = false;
 
   constructor() { }
 
@@ -25,8 +27,10 @@ export class CloseableRowComponent implements OnInit, AfterViewInit {
       this.topLevelElement.nativeElement.style.cssText = '--body-padding: 16px 24px;';
     }
     this.showContent = this.startExpanded;
+    if (this.startExpanded) {
+      this.showOverflow = true;
+    }
   }
-
   ngAfterViewInit() {
     // to omit any init emit
     this.toggleEnabled = true;
@@ -38,5 +42,21 @@ export class CloseableRowComponent implements OnInit, AfterViewInit {
     }
     this.showContent = !this.showContent;
     this.newOpenState.emit(this.showContent);
+
+    this.isChangingState = false;
+    if (this.showContent) {
+        requestAnimationFrame(() => {
+        this.showOverflow = true;
+      });
+    }
+  }
+
+  headerClicked() {
+    this.isChangingState = true;
+    if (this.showContent) {
+      requestAnimationFrame(() => {
+        this.showOverflow = false;
+      });
+    }
   }
 }

--- a/projects/hal-components/src/lib/components/closeable-row/closeable-row.component.ts
+++ b/projects/hal-components/src/lib/components/closeable-row/closeable-row.component.ts
@@ -24,7 +24,7 @@ export class CloseableRowComponent implements OnInit, AfterViewInit {
     if (this.noPadding) {
       this.topLevelElement.nativeElement.style.cssText = '--body-padding: 0px 0px;';
     } else {
-      this.topLevelElement.nativeElement.style.cssText = '--body-padding: 16px 24px;';
+      this.topLevelElement.nativeElement.style.cssText = '--body-padding: var(--hdd-spacing-2) var(--hdd-spacing-3);';
     }
     this.showContent = this.startExpanded;
     if (this.startExpanded) {


### PR DESCRIPTION
Added check on mat-panel in closeable-row to set overflow visible when panel is expanded, and hidden when not. 